### PR TITLE
homescreen shortcuts for new_contact and new_event added

### DIFF
--- a/android_app/app/src/main/AndroidManifest.xml
+++ b/android_app/app/src/main/AndroidManifest.xml
@@ -20,6 +20,8 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                        android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".NewContactActivity"

--- a/android_app/app/src/main/res/drawable/ic_contact_shortcut.xml
+++ b/android_app/app/src/main/res/drawable/ic_contact_shortcut.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/android_app/app/src/main/res/drawable/ic_event_shortcut.xml
+++ b/android_app/app/src/main/res/drawable/ic_event_shortcut.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16,11c1.66,0 2.99,-1.34 2.99,-3S17.66,5 16,5c-1.66,0 -3,1.34 -3,3s1.34,3 3,3zM8,11c1.66,0 2.99,-1.34 2.99,-3S9.66,5 8,5C6.34,5 5,6.34 5,8s1.34,3 3,3zM8,13c-2.33,0 -7,1.17 -7,3.5L1,19h14v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5zM16,13c-0.29,0 -0.62,0.02 -0.97,0.05 1.16,0.84 1.97,1.97 1.97,3.45L17,19h6v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5z"/>
+</vector>

--- a/android_app/app/src/main/res/xml/shortcuts.xml
+++ b/android_app/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="new_contact"
+        android:enabled="true"
+        android:icon="@drawable/ic_contact_shortcut"
+        android:shortcutShortLabel="@string/new_contact"
+        android:shortcutLongLabel="@string/new_contact">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.apozas.contactdiary"
+            android:targetClass="com.apozas.contactdiary.NewContactActivity" />
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="new_event"
+        android:enabled="true"
+        android:icon="@drawable/ic_event_shortcut"
+        android:shortcutShortLabel="@string/new_event"
+        android:shortcutLongLabel="@string/new_event">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.apozas.contactdiary"
+            android:targetClass="com.apozas.contactdiary.NewEventActivity" />
+    </shortcut>
+
+
+</shortcuts>


### PR DESCRIPTION
@apozas First thank you for providing this app! 

What's added: 
Home Screen shortcuts according to [this manual](https://developer.android.com/guide/topics/ui/shortcuts/creating-shortcuts#static) and [this video](https://www.youtube.com/watch?v=-uuhUfItN9Y)

Motivation: I heavily use these shortcuts as they take less taps to reach my target menu

Successfully tested on: 
1. Android studio's emulated Google Pixel running Android 11
2. Pocophone f1 running Android 10
3. BQ Aquaris U running Android 7

Also I proofread the german translation in crowdin.
Since this is my first android pull request please don't be mad at me if I forgot something that's obvious for you...